### PR TITLE
add foreign key check

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -401,6 +401,8 @@ export default function Canvas() {
   };
 
   const handleGripField = (field) => {
+      // A field can be a foreign key only if it's a primary key or both NOT NULL and UNIQUE.
+      // If it can't be selected, show an error message and exit.
       if (!field.primary && !(field.notNull && field.unique)) {
         Toast.info(t("cannot_fk"));
         return;

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -400,7 +400,11 @@ export default function Canvas() {
     });
   };
 
-  const handleGripField = () => {
+  const handleGripField = (field) => {
+      if (!field.primary && !(field.notNull && field.unique)) {
+        Toast.info(t("cannot_fk"));
+        return;
+      }
     setPanning((old) => ({ ...old, isPanning: false }));
     setDragging({ element: ObjectType.NONE, id: -1, prevX: 0, prevY: 0 });
     setLinking(true);

--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -317,10 +317,10 @@ export default function Table(props) {
             onPointerDown={(e) => {
               if (!e.isPrimary) return;
 
-              handleGripField(index);
+              handleGripField(fieldData);
               setLinkingLine((prev) => ({
                 ...prev,
-                startFieldId: index,
+                startFieldId: fieldData.id,
                 startTableId: tableData.id,
                 startX: tableData.x + 15,
                 startY:

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -146,7 +146,7 @@ const en = {
     relationship_deleted: "Relationship deleted",
     type_deleted: "Type deleted",
     cannot_connect: "Cannot connect, the columns have different types",
-    cannot_fk: "Only fields that are a primary key or both not null and unique can be selected as a foreign key.",
+    cannot_fk: "Only fields that are a primary key or both not null and unique can be selected as a foreign key",
     copied_to_clipboard: "Copied to clipboard",
     create_new_diagram: "Create new diagram",
     cancel: "Cancel",

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -146,7 +146,7 @@ const en = {
     relationship_deleted: "Relationship deleted",
     type_deleted: "Type deleted",
     cannot_connect: "Cannot connect, the columns have different types",
-    cannot_fk: "Cannot create foreign key from this field",
+    cannot_fk: "Only fields that are a primary key or both not null and unique can be selected as a foreign key.",
     copied_to_clipboard: "Copied to clipboard",
     create_new_diagram: "Create new diagram",
     cancel: "Cancel",

--- a/src/i18n/locales/en.js
+++ b/src/i18n/locales/en.js
@@ -146,6 +146,7 @@ const en = {
     relationship_deleted: "Relationship deleted",
     type_deleted: "Type deleted",
     cannot_connect: "Cannot connect, the columns have different types",
+    cannot_fk: "Cannot create foreign key from this field",
     copied_to_clipboard: "Copied to clipboard",
     create_new_diagram: "Create new diagram",
     cancel: "Cancel",


### PR DESCRIPTION
Se añadió la funcionalidad para que solo sea posible formar una FK desde un campo válido. Este tiene que ser una llave primaria o ser único y no nulo.

Cuando se puede usar el campo como llave foránea funciona normalmente:

![image](https://github.com/user-attachments/assets/b37eaf89-60d0-4e06-8af4-13c0dbfb6373)

![image](https://github.com/user-attachments/assets/d264b3e6-4935-45c7-8d26-8f6da49ad20a)

Cuando no es posible utilizar el campo como llave foránea se muestra un mensaje:

![image](https://github.com/user-attachments/assets/a31e0233-98be-4e73-92c0-9fc23b04f2f9)
