### PR TITLE
Boton pk

### DIFF
--- a/d
+++ b/d
@@ -1,0 +1,6 @@
+* [32mbotonPK[m
+  main[m
+  notation[m
+  punto1.5[m
+  rama1[m
+  rama1.0[m

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@uiw/codemirror-theme-github": "^4.21.25",
         "@uiw/codemirror-theme-vscode": "^4.21.25",
         "@uiw/react-codemirror": "^4.21.25",
+        "@vercel/analytics": "^1.2.2",
         "axios": "^1.7.4",
         "classnames": "^2.5.1",
         "dexie": "^3.2.4",
@@ -4204,6 +4205,44 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.2.1",

--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -167,7 +167,7 @@ export default function TableField({ data, tid, index }) {
             
             updateField(tid, index, { notNull: !data.notNull });
 
-          //}
+          
 
           }}
         >

--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -136,9 +136,63 @@ export default function TableField({ data, tid, index }) {
         <Button
           type={data.notNull || data.primary ? "primary" : "tertiary"}
           title={t("not_null")}
-          theme={data.notNull || data.primary ? "solid" : "light"}
-          disabled={data.primary ? true: false }
+          theme={data.notNull ? "solid" : "light"}
+         
+         
           onClick={() => {
+                if(data.primary){
+                  
+                  return};
+
+            setUndoStack((prev) => [
+              ...prev,
+              {
+                
+                action: Action.EDIT,
+                element: ObjectType.TABLE,
+                component: "field",
+                tid: tid,
+                fid: index,
+                undo: { notNull: data.notNull },
+                
+                redo: { notNull: !data.notNull },
+                
+                message: t("edit_table", {
+                  tableName: tables[tid].name,
+                  extra: "[field]",
+                }),
+              },
+            ]);
+            setRedoStack([]);
+            
+            updateField(tid, index, { notNull: !data.notNull });
+
+          //}
+
+          }}
+        >
+          ?
+        </Button>
+      </Col>
+      <Col span={3}>
+        <Button
+          type={data.primary ? "primary" : "tertiary"}
+          title={t("primary")}
+          theme={data.primary ? "solid" : "light"}
+          onClick={() => {
+
+            const newStatePK=!data.primary;
+            const stateNull=newStatePK?true: !data.notNull;
+            const mustSetNotNull = !data.primary && !data.notNull;
+            const changes = { primary: !data.primary };
+             
+          const undo= { primary: data.primary , notNull : data.notNull };
+          const redo= { primary: newStatePK , notNull:stateNull };
+          if (mustSetNotNull) {
+            undo.notNull = data.notNull;
+            redo.notNull = true;
+            changes.notNull = true;
+          }      
             setUndoStack((prev) => [
               ...prev,
               {
@@ -147,8 +201,7 @@ export default function TableField({ data, tid, index }) {
                 component: "field",
                 tid: tid,
                 fid: index,
-                undo: { notNull: data.notNull },
-                redo: { notNull: !data.notNull },
+                
                 message: t("edit_table", {
                   tableName: tables[tid].name,
                   extra: "[field]",
@@ -156,52 +209,11 @@ export default function TableField({ data, tid, index }) {
               },
             ]);
             setRedoStack([]);
-            updateField(tid, index, { notNull: !data.notNull });
+            updateField(tid, index, { primary: newStatePK,notNull:stateNull });
           }}
-        >
-          ?
-        </Button>
-      </Col>
-      <Col span={3}>
-      <Button
-        type={data.primary ? "primary" : "tertiary"}
-        title={t("primary")}
-        theme={data.primary ? "solid" : "light"}
-        onClick={() => {
-          const mustSetNotNull = !data.primary && !data.notNull;
-
-          const undo = { primary: data.primary };
-          const redo = { primary: !data.primary };
-          const changes = { primary: !data.primary };
-
-          if (mustSetNotNull) {
-            undo.notNull = data.notNull;
-            redo.notNull = true;
-            changes.notNull = true;
-          }
-
-          setUndoStack((prev) => [
-            ...prev,
-            {
-              action: Action.EDIT,
-              element: ObjectType.TABLE,
-              component: "field",
-              tid,
-              fid: index,
-              undo,
-              redo,
-              message: t("edit_table", {
-                tableName: tables[tid].name,
-                extra: "[field]",
-              }),
-            },
-          ]);
-
-          setRedoStack([]);
-          updateField(tid, index, changes);
-        }}
-        icon={<IconKeyStroked />}
-      />
+          icon={<IconKeyStroked />}
+        />
+      
 
       </Col>
       <Col span={3}>


### PR DESCRIPTION
Se realizó la modificación acorde al requerimiento 1.5, en el cual se solicita que un PK no debe de ser nuleable, modificando las acciones del botón “not_null” y “primary” colocando condicionales y actualizaciones de estados, es decir que se cambie automáticamente a not_null cuando es un PK y no se pueda modificar “not_null” .