### PR TITLE
add delete shortcut control + backspace and command + backspace

### DIFF
--- a/src/components/EditorHeader/ControlPanel.jsx
+++ b/src/components/EditorHeader/ControlPanel.jsx
@@ -1163,7 +1163,7 @@ export default function ControlPanel({
       },
       delete: {
         function: del,
-        shortcut: "Del",
+        shortcut: "Del / Ctrl + Backspace",
       },
       copy_as_image: {
         function: copyAsImage,
@@ -1390,7 +1390,7 @@ export default function ControlPanel({
   useHotkeys("ctrl+c, meta+c", copy, { preventDefault: true });
   useHotkeys("ctrl+v, meta+v", paste, { preventDefault: true });
   useHotkeys("ctrl+x, meta+x", cut, { preventDefault: true });
-  useHotkeys("delete", del, { preventDefault: true });
+  useHotkeys("delete, ctrl+backspace, meta+backspace", del, { preventDefault: true });
   useHotkeys("ctrl+shift+g, meta+shift+g", viewGrid, { preventDefault: true });
   useHotkeys("ctrl+up, meta+up", zoomIn, { preventDefault: true });
   useHotkeys("ctrl+down, meta+down", zoomOut, { preventDefault: true });

--- a/src/data/shortcuts.js
+++ b/src/data/shortcuts.js
@@ -10,7 +10,7 @@ export const shortcuts = [
   { shortcut: "CTRL+V", title: "Paste selected element", description: "" },
   { shortcut: "CTRL+X", title: "Cut selected element", description: "" },
   { shortcut: "CTRL+D", title: "Duplicate selected element", description: "" },
-  { shortcut: "DEL", title: "Delete selected element", description: "" },
+  { shortcut: "DEL / CTRL + BACKSPACE", title: "Delete selected element", description: "" },
   { shortcut: "CTRL+E", title: "Edit selected element", description: "" },
   {
     shortcut: "CTRL+I",


### PR DESCRIPTION
Ahora es posible eliminar elementos utilizando el comando Ctrl + Backspace y Command + Backspace en Mac. 

Se añadió el atajo de teclado y se modificaron las líneas donde se muestra al usuario como utilizarlo.