### PR TITLE
add names to indices list and improve layout for better display

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
+++ b/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
@@ -1,5 +1,5 @@
 import { Action, ObjectType } from "../../../data/constants";
-import { Input, Button, Popover, Checkbox, Select } from "@douyinfe/semi-ui";
+import { Input, Button, Popover, Checkbox, Select, Row, Col } from "@douyinfe/semi-ui";
 import { IconMore, IconDeleteStroked } from "@douyinfe/semi-icons";
 import { useDiagram, useUndoRedo } from "../../../hooks";
 import { useTranslation } from "react-i18next";
@@ -12,181 +12,228 @@ export default function IndexDetails({ data, fields, iid, tid }) {
   const [editField, setEditField] = useState({});
 
   return (
-    <div className="flex justify-between items-center mb-2">
-      <Select
-        placeholder={t("select_fields")}
-        multiple
-        validateStatus={data.fields.length === 0 ? "error" : "default"}
-        optionList={fields}
-        className="w-full"
-        value={data.fields}
-        onChange={(value) => {
-          setUndoStack((prev) => [
-            ...prev,
-            {
-              action: Action.EDIT,
-              element: ObjectType.TABLE,
-              component: "index",
-              tid: tid,
-              iid: iid,
-              undo: {
-                fields: [...data.fields],
+    <Row gutter={6} className="hover-1 my-2">
+      <Col span={8}>
+          <Input
+          value={data.name}
+          placeholder={t("name")}
+          validateStatus={data.name.trim() === "" ? "error" : "default"}
+          onFocus={() =>
+              setEditField({
+              name: data.name,
+              })
+          }
+          onChange={(value) =>
+              updateTable(tid, {
+              indices: tables[tid].indices.map((index) =>
+                  index.id === iid
+                  ? {
+                      ...index,
+                      name: value,
+                      }
+                  : index,
+              ),
+              })
+          }
+          onBlur={(e) => {
+              if (e.target.value === editField.name) return;
+              setUndoStack((prev) => [
+              ...prev,
+              {
+                  action: Action.EDIT,
+                  element: ObjectType.TABLE,
+                  component: "index",
+                  tid: tid,
+                  iid: iid,
+                  undo: editField,
+                  redo: { name: e.target.value },
+                  message: t("edit_table", {
+                  tableName: tables[tid].name,
+                  extra: "[index]",
+                  }),
               },
-              redo: {
-                fields: [...value],
-              },
-              message: t("edit_table", {
-                tableName: tables[tid].name,
-                extra: "[index field]",
-              }),
-            },
-          ]);
-          setRedoStack([]);
-          updateTable(tid, {
-            indices: tables[tid].indices.map((index) =>
-              index.id === iid
-                ? {
-                    ...index,
-                    fields: [...value],
-                  }
-                : index,
-            ),
-          });
-        }}
-      />
-      <Popover
-        content={
-          <div className="px-1 popover-theme">
-            <div className="font-semibold mb-1">{t("name")}: </div>
-            <Input
-              value={data.name}
-              placeholder={t("name")}
-              validateStatus={data.name.trim() === "" ? "error" : "default"}
-              onFocus={() =>
-                setEditField({
-                  name: data.name,
-                })
-              }
-              onChange={(value) =>
-                updateTable(tid, {
-                  indices: tables[tid].indices.map((index) =>
-                    index.id === iid
-                      ? {
-                          ...index,
-                          name: value,
-                        }
-                      : index,
-                  ),
-                })
-              }
-              onBlur={(e) => {
-                if (e.target.value === editField.name) return;
-                setUndoStack((prev) => [
-                  ...prev,
-                  {
-                    action: Action.EDIT,
-                    element: ObjectType.TABLE,
-                    component: "index",
-                    tid: tid,
-                    iid: iid,
-                    undo: editField,
-                    redo: { name: e.target.value },
-                    message: t("edit_table", {
-                      tableName: tables[tid].name,
-                      extra: "[index]",
-                    }),
-                  },
-                ]);
-                setRedoStack([]);
-              }}
-            />
-            <div className="flex justify-between items-center my-3">
-              <div className="font-medium">{t("unique")}</div>
-              <Checkbox
-                value="unique"
-                checked={data.unique}
-                onChange={(checkedValues) => {
-                  setUndoStack((prev) => [
-                    ...prev,
-                    {
-                      action: Action.EDIT,
-                      element: ObjectType.TABLE,
-                      component: "index",
-                      tid: tid,
-                      iid: iid,
-                      undo: {
-                        [checkedValues.target.value]:
-                          !checkedValues.target.checked,
-                      },
-                      redo: {
-                        [checkedValues.target.value]:
-                          checkedValues.target.checked,
-                      },
-                      message: t("edit_table", {
-                        tableName: tables[tid].name,
-                        extra: "[index field]",
-                      }),
-                    },
-                  ]);
-                  setRedoStack([]);
-                  updateTable(tid, {
+              ]);
+              setRedoStack([]);
+          }}
+          />
+      </Col>
+      <Col span={12}>
+        <Select
+            placeholder={t("select_fields")}
+            multiple
+            validateStatus={data.fields.length === 0 ? "error" : "default"}
+            optionList={fields}
+            className="w-full"
+            value={data.fields}
+            onChange={(value) => {
+            setUndoStack((prev) => [
+                ...prev,
+                {
+                action: Action.EDIT,
+                element: ObjectType.TABLE,
+                component: "index",
+                tid: tid,
+                iid: iid,
+                undo: {
+                    fields: [...data.fields],
+                },
+                redo: {
+                  fields: [...value],
+                },
+                message: t("edit_table", {
+                    tableName: tables[tid].name,
+                    extra: "[index field]",
+                }),
+                },
+            ]);
+            setRedoStack([]);
+            updateTable(tid, {
+                indices: tables[tid].indices.map((index) =>
+                index.id === iid
+                    ? {
+                        ...index,
+                        fields: [...value],
+                    }
+                    : index,
+                ),
+            });
+            }}
+        />
+      </Col>
+      <Col span={3}>
+        <Popover
+            content={
+            <div className="px-1 popover-theme">
+                <div className="font-semibold mb-1">{t("name")}: </div>
+                <Input
+                value={data.name}
+                placeholder={t("name")}
+                validateStatus={data.name.trim() === "" ? "error" : "default"}
+                onFocus={() =>
+                    setEditField({
+                    name: data.name,
+                    })
+                }
+                onChange={(value) =>
+                    updateTable(tid, {
                     indices: tables[tid].indices.map((index) =>
-                      index.id === iid
+                        index.id === iid
                         ? {
                             ...index,
-                            [checkedValues.target.value]:
-                              checkedValues.target.checked,
-                          }
+                            name: value,
+                            }
                         : index,
                     ),
-                  });
+                    })
+                }
+                onBlur={(e) => {
+                    if (e.target.value === editField.name) return;
+                    setUndoStack((prev) => [
+                    ...prev,
+                    {
+                        action: Action.EDIT,
+                        element: ObjectType.TABLE,
+                        component: "index",
+                        tid: tid,
+                        iid: iid,
+                        undo: editField,
+                        redo: { name: e.target.value },
+                        message: t("edit_table", {
+                        tableName: tables[tid].name,
+                        extra: "[index]",
+                        }),
+                    },
+                    ]);
+                    setRedoStack([]);
                 }}
-              ></Checkbox>
+                />
+                <div className="flex justify-between items-center my-3">
+                <div className="font-medium">{t("unique")}</div>
+                <Checkbox
+                    value="unique"
+                    checked={data.unique}
+                    onChange={(checkedValues) => {
+                    setUndoStack((prev) => [
+                        ...prev,
+                        {
+                        action: Action.EDIT,
+                        element: ObjectType.TABLE,
+                        component: "index",
+                        tid: tid,
+                        iid: iid,
+                        undo: {
+                            [checkedValues.target.value]:
+                            !checkedValues.target.checked,
+                        },
+                        redo: {
+                            [checkedValues.target.value]:
+                            checkedValues.target.checked,
+                        },
+                        message: t("edit_table", {
+                            tableName: tables[tid].name,
+                            extra: "[index field]",
+                        }),
+                        },
+                    ]);
+                    setRedoStack([]);
+                    updateTable(tid, {
+                        indices: tables[tid].indices.map((index) =>
+                        index.id === iid
+                            ? {
+                                ...index,
+                                [checkedValues.target.value]:
+                                checkedValues.target.checked,
+                            }
+                            : index,
+                        ),
+                    });
+                    }}
+                ></Checkbox>
+                </div>
+                <Button
+                icon={<IconDeleteStroked />}
+                type="danger"
+                block
+                onClick={() => {
+                    setUndoStack((prev) => [
+                    ...prev,
+                    {
+                        action: Action.EDIT,
+                        element: ObjectType.TABLE,
+                        component: "index_delete",
+                        tid: tid,
+                        data: data,
+                        message: t("edit_table", {
+                        tableName: tables[tid].name,
+                        extra: "[delete index]",
+                        }),
+                    },
+                    ]);
+                    setRedoStack([]);
+                    updateTable(tid, {
+                    indices: tables[tid].indices
+                        .filter((e) => e.id !== iid)
+                        .map((e, j) => ({
+                        ...e,
+                        id: j,
+                        })),
+                    });
+                }}
+                >
+                {t("delete")}
+                </Button>
             </div>
+            }
+            trigger="click"
+            position="rightTop"
+            showArrow
+        >
             <Button
-              icon={<IconDeleteStroked />}
-              type="danger"
-              block
-              onClick={() => {
-                setUndoStack((prev) => [
-                  ...prev,
-                  {
-                    action: Action.EDIT,
-                    element: ObjectType.TABLE,
-                    component: "index_delete",
-                    tid: tid,
-                    data: data,
-                    message: t("edit_table", {
-                      tableName: tables[tid].name,
-                      extra: "[delete index]",
-                    }),
-                  },
-                ]);
-                setRedoStack([]);
-                updateTable(tid, {
-                  indices: tables[tid].indices
-                    .filter((e) => e.id !== iid)
-                    .map((e, j) => ({
-                      ...e,
-                      id: j,
-                    })),
-                });
-              }}
-            >
-              {t("delete")}
-            </Button>
-          </div>
-        }
-        trigger="click"
-        position="rightTop"
-        showArrow
-      >
-        <Button
-          icon={<IconMore />}
-          type="tertiary"
-          style={{ marginLeft: "12px" }}
-        />
-      </Popover>
-    </div>
+            icon={<IconMore />}
+            type="tertiary"
+            />
+        </Popover>
+      </Col>
+    </Row>
   );
 }

--- a/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
+++ b/src/components/EditorSidePanel/TablesTab/IndexDetails.jsx
@@ -1,6 +1,6 @@
 import { Action, ObjectType } from "../../../data/constants";
-import { Input, Button, Popover, Checkbox, Select, Row, Col } from "@douyinfe/semi-ui";
-import { IconMore, IconDeleteStroked } from "@douyinfe/semi-icons";
+import { Input, Button, Checkbox, Select, Row, Col } from "@douyinfe/semi-ui";
+import { IconDeleteStroked } from "@douyinfe/semi-icons";
 import { useDiagram, useUndoRedo } from "../../../hooks";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
@@ -12,99 +12,9 @@ export default function IndexDetails({ data, fields, iid, tid }) {
   const [editField, setEditField] = useState({});
 
   return (
-    <Row gutter={6} className="hover-1 my-2">
-      <Col span={8}>
-          <Input
-          value={data.name}
-          placeholder={t("name")}
-          validateStatus={data.name.trim() === "" ? "error" : "default"}
-          onFocus={() =>
-              setEditField({
-              name: data.name,
-              })
-          }
-          onChange={(value) =>
-              updateTable(tid, {
-              indices: tables[tid].indices.map((index) =>
-                  index.id === iid
-                  ? {
-                      ...index,
-                      name: value,
-                      }
-                  : index,
-              ),
-              })
-          }
-          onBlur={(e) => {
-              if (e.target.value === editField.name) return;
-              setUndoStack((prev) => [
-              ...prev,
-              {
-                  action: Action.EDIT,
-                  element: ObjectType.TABLE,
-                  component: "index",
-                  tid: tid,
-                  iid: iid,
-                  undo: editField,
-                  redo: { name: e.target.value },
-                  message: t("edit_table", {
-                  tableName: tables[tid].name,
-                  extra: "[index]",
-                  }),
-              },
-              ]);
-              setRedoStack([]);
-          }}
-          />
-      </Col>
-      <Col span={12}>
-        <Select
-            placeholder={t("select_fields")}
-            multiple
-            validateStatus={data.fields.length === 0 ? "error" : "default"}
-            optionList={fields}
-            className="w-full"
-            value={data.fields}
-            onChange={(value) => {
-            setUndoStack((prev) => [
-                ...prev,
-                {
-                action: Action.EDIT,
-                element: ObjectType.TABLE,
-                component: "index",
-                tid: tid,
-                iid: iid,
-                undo: {
-                    fields: [...data.fields],
-                },
-                redo: {
-                  fields: [...value],
-                },
-                message: t("edit_table", {
-                    tableName: tables[tid].name,
-                    extra: "[index field]",
-                }),
-                },
-            ]);
-            setRedoStack([]);
-            updateTable(tid, {
-                indices: tables[tid].indices.map((index) =>
-                index.id === iid
-                    ? {
-                        ...index,
-                        fields: [...value],
-                    }
-                    : index,
-                ),
-            });
-            }}
-        />
-      </Col>
-      <Col span={3}>
-        <Popover
-            content={
-            <div className="px-1 popover-theme">
-                <div className="font-semibold mb-1">{t("name")}: </div>
+    <div className="hover-1">
+        <Row gutter={6} className="my-2 flex items-center">
+            <Col span={16}>
                 <Input
                 value={data.name}
                 placeholder={t("name")}
@@ -147,7 +57,8 @@ export default function IndexDetails({ data, fields, iid, tid }) {
                     setRedoStack([]);
                 }}
                 />
-                <div className="flex justify-between items-center my-3">
+            </Col>
+            <Col span={7} className="flex justify-between items-center ml-1">
                 <div className="font-medium">{t("unique")}</div>
                 <Checkbox
                     value="unique"
@@ -189,11 +100,56 @@ export default function IndexDetails({ data, fields, iid, tid }) {
                     });
                     }}
                 ></Checkbox>
-                </div>
+            </Col>
+        </Row>
+        <Row gutter={6} className="my-2">
+            <Col span={20}>
+                <Select
+                    placeholder={t("select_fields")}
+                    multiple
+                    validateStatus={data.fields.length === 0 ? "error" : "default"}
+                    optionList={fields}
+                    className="w-full"
+                    value={data.fields}
+                    onChange={(value) => {
+                    setUndoStack((prev) => [
+                        ...prev,
+                        {
+                        action: Action.EDIT,
+                        element: ObjectType.TABLE,
+                        component: "index",
+                        tid: tid,
+                        iid: iid,
+                        undo: {
+                            fields: [...data.fields],
+                        },
+                        redo: {
+                        fields: [...value],
+                        },
+                        message: t("edit_table", {
+                            tableName: tables[tid].name,
+                            extra: "[index field]",
+                        }),
+                        },
+                    ]);
+                    setRedoStack([]);
+                    updateTable(tid, {
+                        indices: tables[tid].indices.map((index) =>
+                        index.id === iid
+                            ? {
+                                ...index,
+                                fields: [...value],
+                            }
+                            : index,
+                        ),
+                    });
+                    }}
+                />
+            </Col>
+            <Col span={3}>
                 <Button
                 icon={<IconDeleteStroked />}
                 type="danger"
-                block
                 onClick={() => {
                     setUndoStack((prev) => [
                     ...prev,
@@ -220,20 +176,9 @@ export default function IndexDetails({ data, fields, iid, tid }) {
                     });
                 }}
                 >
-                {t("delete")}
                 </Button>
-            </div>
-            }
-            trigger="click"
-            position="rightTop"
-            showArrow
-        >
-            <Button
-            icon={<IconMore />}
-            type="tertiary"
-            />
-        </Popover>
-      </Col>
-    </Row>
+            </Col>
+        </Row>
+    </div>
   );
 }


### PR DESCRIPTION
Se agregó un input para mostrar y editar el nombre de cada índice en la lista de índices de cada tabla. 

Se reutilizó el mismo input que se muestra en las opciones de cada índice. Además, se aplicó el mismo estilo utilizado en la visualización de los campos de las tablas, usando los componentes `Row` y `Col` de la biblioteca semi-ui.

Cada elemento se agrupó en un componente `Col` y todos están dentro de un contenedor `Row`.

Imagen de antes del cambio:

![image](https://github.com/user-attachments/assets/5c6956ad-5662-4f70-8dc2-f58092910334)

Imagen después del cambio:

![image](https://github.com/user-attachments/assets/c37e4e22-d531-49ac-88bb-45624b05f416)

