### PR TITLE
Fix: Fixing the area selection for moving multiple objects and their undo/redo component

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -75,7 +75,7 @@ export default function Canvas() {
   const { notes, updateNote } = useNotes();
   const { layout } = useLayout();
   const { settings } = useSettings();
-  const { setUndoStack, setRedoStack, pushUndo } = useUndoRedo();
+  const { setRedoStack, pushUndo } = useUndoRedo();
 
   const { selectedElement, setSelectedElement } = useSelect();
   const [dragging, setDragging] = useState({
@@ -597,13 +597,7 @@ export default function Canvas() {
     const info = getMovedElementDetails();
     // Use pushUndo to ensure centralized filtering/deduplication
     pushUndo((() => {
-      if (Array.isArray(dragging.id)) {
-        const arraysEqual = (a1, a2) => {
-          if (!Array.isArray(a1) || !Array.isArray(a2)) return false;
-          if (a1.length !== a2.length) return false;
-          for (let i = 0; i < a1.length; i++) if (a1[i] !== a2[i]) return false;
-          return true;
-        };
+  if (Array.isArray(dragging.id)) {
 
         // Build arrays matching ControlPanel's expected shape: originalPositions/newPositions
         const originalPositionsArray = (dragging.initialPositions && typeof dragging.initialPositions === 'object')

--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -6,6 +6,8 @@ import {
   Constraint,
   darkBgTheme,
   ObjectType,
+  tableFieldHeight,
+  tableHeaderHeight,
 } from "../../data/constants";
 import { Toast } from "@douyinfe/semi-ui";
 import Table from "./Table";
@@ -544,13 +546,34 @@ export default function Canvas() {
 
     if (isAreaSelecting) {
       const areaBBox = selectionArea;
+      // Select tables that intersect the selection area (any part of table)
       const selectedTables = tables.filter((table) => {
-        return (
-          table.x >= areaBBox.x &&
-          table.x <= areaBBox.x + areaBBox.width &&
-          table.y >= areaBBox.y &&
-          table.y <= areaBBox.y + areaBBox.height
+        const tableX = table.x;
+        const tableY = table.y;
+        const tableWidth = table.width || settings.tableWidth;
+        const tableHeight = (table.fields?.length || 0) * tableFieldHeight + tableHeaderHeight + 7;
+
+        const tableRect = {
+          x: tableX,
+          y: tableY,
+          width: tableWidth,
+          height: tableHeight,
+        };
+
+        const areaRect = {
+          x: areaBBox.x,
+          y: areaBBox.y,
+          width: areaBBox.width,
+          height: areaBBox.height,
+        };
+
+        const intersects = !(
+          tableRect.x + tableRect.width < areaRect.x ||
+          tableRect.x > areaRect.x + areaRect.width ||
+          tableRect.y + tableRect.height < areaRect.y ||
+          tableRect.y > areaRect.y + areaRect.height
         );
+        return intersects;
       });
 
       if (selectedTables.length > 0) {

--- a/src/context/UndoRedoContext.jsx
+++ b/src/context/UndoRedoContext.jsx
@@ -1,19 +1,73 @@
-import { createContext, useState } from "react";
+import { createContext, useState, useCallback } from "react";
+import { Action } from "../data/constants";
 
 export const UndoRedoContext = createContext({
   undoStack: [],
-  setUndoStack: () => {},
   redoStack: [],
-  setRedoStack: () => {},
+  pushUndo: () => {},
+  pushRedo: () => {},
+  clearUndoRedo: () => {},
 });
 
 export default function UndoRedoContextProvider({ children }) {
   const [undoStack, setUndoStack] = useState([]);
   const [redoStack, setRedoStack] = useState([]);
 
+  // Helper to push an action into the undo stack with basic filtering
+  const pushUndo = useCallback((action) => {
+    if (!action) return;
+
+      // Only accept real mutation actions to avoid recording trivial UI interactions
+      const allowedActionNames = new Set(["MOVE", "ADD", "DELETE", "EDIT", "PAN"]);
+      const allowedActionNums = new Set([Action.MOVE, Action.ADD, Action.DELETE, Action.EDIT, Action.PAN]);
+
+      // action.action may be numeric constant (Action enum) or string
+      if (typeof action.action === 'number') {
+        if (!allowedActionNums.has(action.action)) return;
+      } else if (typeof action.action === 'string') {
+        if (!allowedActionNames.has(action.action)) return;
+      } else {
+        // If no explicit action type, ignore
+        return;
+      }
+
+    // Avoid pushing duplicate consecutive actions (shallow compare by JSON)
+    const last = undoStack[undoStack.length - 1];
+    try {
+      const sLast = JSON.stringify(last);
+      const sAction = JSON.stringify(action);
+      if (sLast === sAction) return;
+    } catch (e) {
+      // If stringify fails, skip duplicate check
+    }
+
+  // No-op: intentionally do not log in production; tracing was used for debugging
+  // during development and has been removed to keep console clean.
+
+    setUndoStack((prev) => [...prev, action]);
+    // pushing a new undo clears redo
+    setRedoStack([]);
+  }, [undoStack]);
+
+  const pushRedo = useCallback((action) => {
+    if (!action) return;
+    const last = redoStack[redoStack.length - 1];
+    try {
+      const sLast = JSON.stringify(last);
+      const sAction = JSON.stringify(action);
+      if (sLast === sAction) return;
+    } catch (e) {}
+    setRedoStack((prev) => [...prev, action]);
+  }, [redoStack]);
+
+  const clearUndoRedo = useCallback(() => {
+    setUndoStack([]);
+    setRedoStack([]);
+  }, []);
+
   return (
     <UndoRedoContext.Provider
-      value={{ undoStack, redoStack, setUndoStack, setRedoStack }}
+      value={{ undoStack, redoStack, setUndoStack, setRedoStack, pushUndo, pushRedo, clearUndoRedo }}
     >
       {children}
     </UndoRedoContext.Provider>

--- a/src/context/UndoRedoContext.jsx
+++ b/src/context/UndoRedoContext.jsx
@@ -41,9 +41,6 @@ export default function UndoRedoContextProvider({ children }) {
       // If stringify fails, skip duplicate check
     }
 
-  // No-op: intentionally do not log in production; tracing was used for debugging
-  // during development and has been removed to keep console clean.
-
     setUndoStack((prev) => [...prev, action]);
     // pushing a new undo clears redo
     setRedoStack([]);
@@ -56,7 +53,9 @@ export default function UndoRedoContextProvider({ children }) {
       const sLast = JSON.stringify(last);
       const sAction = JSON.stringify(action);
       if (sLast === sAction) return;
-    } catch (e) {}
+    } catch (e) {
+      // ignore JSON stringify errors for non-serializable actions
+    }
     setRedoStack((prev) => [...prev, action]);
   }, [redoStack]);
 


### PR DESCRIPTION
This pull request aims to fix a bug related to moving objects using area selection, thus allowing for greater interaction with the modeler. In addition, significant bugs in the Undo/Redo component have been fixed so that when moving an object, a single CTRL+Z is required to return it to its original position and a single CTRL+Y is required to return it to the position in which the object was moved.

