### PR TITLE
feature: add field creation and auto-focus on enter key in tables

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -7,12 +7,13 @@ import FieldDetails from "./FieldDetails";
 import { useTranslation } from "react-i18next";
 import { dbToTypes } from "../../../data/datatypes";
 import { Toast } from "@douyinfe/semi-ui";
+import { createNewField } from "./createNewField";
 
 export default function TableField({ data, tid, index }) {
   const { updateField } = useDiagram();
   const { types } = useTypes();
   const { enums } = useEnums();
-  const { tables, database } = useDiagram();
+  const { tables, database, addFieldToTable } = useDiagram();
   const { t } = useTranslation();
   const { setUndoStack, setRedoStack } = useUndoRedo();
   const [editField, setEditField] = useState({});
@@ -29,6 +30,30 @@ export default function TableField({ data, tid, index }) {
           onChange={(value) => updateField(tid, index, {
               name: settings.upperCaseFields ? value.toUpperCase() : value.toLowerCase()
           })}
+          onKeyUp={(e) => {
+            if (e.key === "Enter") {
+                //When pressing enter, focus the next input, if there is no next input, create a new field and focus it
+                const input = document.getElementById(`scroll_table_${tid}_input_${index+1}`);
+                if (input) input.focus();
+                else {
+                    createNewField({
+                        data,
+                        settings,
+                        database,
+                        dbToTypes,
+                        addFieldToTable,
+                        setUndoStack,
+                        setRedoStack,
+                        t,
+                        tid,
+                    });
+                    setTimeout(() => {
+                        const newInput = document.getElementById(`scroll_table_${tid}_input_${index+1}`);
+                        if (newInput) newInput.focus();
+                    }, 0);
+                }
+            }
+          }}
           onFocus={(e) => setEditField({ name: e.target.value })}
           onBlur={(e) => {
             if (e.target.value === editField.name) return;

--- a/src/components/EditorSidePanel/TablesTab/createNewField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/createNewField.jsx
@@ -1,0 +1,114 @@
+import { Action, ObjectType, defaultBlue } from "../../../data/constants";
+
+export function createNewField({
+  data,
+  settings,
+  database,
+  dbToTypes,
+  addFieldToTable,
+  setUndoStack,
+  setRedoStack,
+  t,
+  tid,
+}) {
+    setUndoStack((prev) => [
+      ...prev,
+      {
+        action: Action.EDIT,
+        element: ObjectType.TABLE,
+        component: "self",
+        tid: tid,
+        undo: { color: data.color },
+        redo: { color: defaultBlue },
+        message: t("edit_table", {
+          tableName: data.name,
+          extra: "[color]",
+        }),
+      },
+    ]);
+    setRedoStack([]);
+
+    const incr = data.increment && !!dbToTypes[database][settings.defaultFieldType].canIncrement;
+    // Function to get the default size configured by the user
+    const getUserDefaultSize = (typeName) => {
+      const dbSettings = settings?.defaultTypeSizes?.[database] || {};
+      const userSize = dbSettings[typeName];
+      if (typeof userSize === 'number') {
+        return userSize;
+      }
+      return dbToTypes[database][typeName]?.defaultSize || '';
+    };
+    // Function to get the combined size for types with precision and scale
+    const getUserDefaultPrecisionScale = (typeName) => {
+      const dbSettings = settings?.defaultTypeSizes?.[database] || {};
+      const userSettings = dbSettings[typeName];
+      if (typeof userSettings === 'object') {
+        const precision = userSettings?.precision || 10;
+        const scale = userSettings?.scale;
+        // If it has a defined scale, combine as "precision,scale"
+        if (scale !== undefined && scale !== null) {
+          return `${precision},${scale}`;
+        }
+        // If it only has precision, return just the precision
+        return precision.toString();
+      }
+      // Default value for types with precision
+      return "10";
+    };
+
+    // Base field data
+    const newFieldData = {
+      name: "",
+      type: settings.defaultFieldType,
+      default: "",
+      check: "",
+      primary: false,
+      unique: false,
+      notNull: settings.defaultNotNull,
+      increment: false,
+      comment: "",
+      foreignK: false,
+    };
+
+    // Field updates based on type
+    let fieldUpdates = {
+      increment: incr,
+    };
+
+    if (settings.defaultFieldType === "ENUM" || settings.defaultFieldType === "SET") {
+      fieldUpdates = {
+        ...fieldUpdates,
+        values: data.values ? [...data.values] : [],
+      };
+    } else if (dbToTypes[database][settings.defaultFieldType].hasPrecision) {
+      fieldUpdates = {
+        ...fieldUpdates,
+        size: getUserDefaultPrecisionScale(settings.defaultFieldType),
+      };
+    } else if (dbToTypes[database][settings.defaultFieldType].isSized) {
+      fieldUpdates = {
+        ...fieldUpdates,
+        size: getUserDefaultSize(settings.defaultFieldType),
+      };
+    } else if (!dbToTypes[database][settings.defaultFieldType].hasDefault || incr) {
+      fieldUpdates = {
+        ...fieldUpdates,
+        default: "",
+        size: "",
+        values: [],
+      };
+    } else if (dbToTypes[database][settings.defaultFieldType].hasCheck) {
+      fieldUpdates = {
+        ...fieldUpdates,
+        check: "",
+      };
+    } else {
+      fieldUpdates = {
+        ...fieldUpdates,
+        size: "",
+        values: [],
+      };
+    }
+    // Use the new atomic function
+    addFieldToTable(tid, newFieldData, fieldUpdates);
+}


### PR DESCRIPTION
Move field creation logic to createNewField.jsx and improve field input workflow

- Moved field creation logic from TableInfo.jsx to a new utility file, createNewField.jsx, to enable reuse across multiple components.
- Updated TableField.jsx so that pressing Enter in a field input focuses the next field,  if there is no next field, a new one will be created and focused making the process faster and more intuitive
