### PR TITLE
Fix: Add relationship validation to field context menu primary key toggle

### DIFF
--- a/src/components/EditorCanvas/Canvas.jsx
+++ b/src/components/EditorCanvas/Canvas.jsx
@@ -598,6 +598,14 @@ export default function Canvas() {
         (f) => f.id === fieldContextMenu.fieldId,
       );
       if (table && field) {
+        if (
+          field.primary &&
+          relationships.some((rel) => rel.startTableId === table.id)
+        ) {
+          Toast.info(t("inconsistency_of_data"));
+          return;
+        }
+
         const updatedFields = table.fields.map((f) =>
           f.id === fieldContextMenu.fieldId
             ? {


### PR DESCRIPTION
Prevent removing primary keys from parent tables in relationships, matching side panel behavior #48 