### PR TITLE
fix default data length setting when editing a field type

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 import FieldDetails from "./FieldDetails";
 import { useTranslation } from "react-i18next";
 import { dbToTypes } from "../../../data/datatypes";
+import { getUserDefaultPrecisionScale, getUserDefaultSize } from "../../../utils/typeDefaults";
 import { Toast } from "@douyinfe/semi-ui";
 import { createNewField } from "./createNewField";
 
@@ -170,13 +171,16 @@ export default function TableField({ data, tid, index }) {
                   values: data.values ? [...data.values] : [],
                   increment: incr,
                 });
-              } else if (
-                dbToTypes[database][value].isSized ||
-                dbToTypes[database][value].hasPrecision
-              ) {
+              } else if (dbToTypes[database][value].isSized) {
                 updateField(tid, index, {
                   type: value,
-                  size: dbToTypes[database][value].defaultSize,
+                  size: getUserDefaultSize(value, settings, database, dbToTypes),
+                  increment: incr,
+                });
+              } else if (dbToTypes[database][value].hasPrecision) {
+                updateField(tid, index, {
+                  type: value,
+                  size: getUserDefaultPrecisionScale(value, settings, database),
                   increment: incr,
                 });
               } else if (!dbToTypes[database][value].hasDefault || incr) {

--- a/src/components/EditorSidePanel/TablesTab/createNewField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/createNewField.jsx
@@ -1,4 +1,5 @@
 import { Action, ObjectType } from "../../../data/constants";
+import { getUserDefaultPrecisionScale, getUserDefaultSize } from "../../../utils/typeDefaults";
 
 export function createNewField({
   data,
@@ -22,32 +23,6 @@ export function createNewField({
     });
 
     const incr = data.increment && !!dbToTypes[database][settings.defaultFieldType].canIncrement;
-    // Function to get the default size configured by the user
-    const getUserDefaultSize = (typeName) => {
-      const dbSettings = settings?.defaultTypeSizes?.[database] || {};
-      const userSize = dbSettings[typeName];
-      if (typeof userSize === 'number') {
-        return userSize;
-      }
-      return dbToTypes[database][typeName]?.defaultSize || '';
-    };
-    // Function to get the combined size for types with precision and scale
-    const getUserDefaultPrecisionScale = (typeName) => {
-      const dbSettings = settings?.defaultTypeSizes?.[database] || {};
-      const userSettings = dbSettings[typeName];
-      if (typeof userSettings === 'object') {
-        const precision = userSettings?.precision || 10;
-        const scale = userSettings?.scale;
-        // If it has a defined scale, combine as "precision,scale"
-        if (scale !== undefined && scale !== null) {
-          return `${precision},${scale}`;
-        }
-        // If it only has precision, return just the precision
-        return precision.toString();
-      }
-      // Default value for types with precision
-      return "10";
-    };
 
     // Base field data
     const newFieldData = {
@@ -76,12 +51,12 @@ export function createNewField({
     } else if (dbToTypes[database][settings.defaultFieldType].hasPrecision) {
       fieldUpdates = {
         ...fieldUpdates,
-        size: getUserDefaultPrecisionScale(settings.defaultFieldType),
+        size: getUserDefaultPrecisionScale(settings.defaultFieldType, settings, database),
       };
     } else if (dbToTypes[database][settings.defaultFieldType].isSized) {
       fieldUpdates = {
         ...fieldUpdates,
-        size: getUserDefaultSize(settings.defaultFieldType),
+        size: getUserDefaultSize(settings.defaultFieldType, settings, database, dbToTypes),
       };
     } else if (!dbToTypes[database][settings.defaultFieldType].hasDefault || incr) {
       fieldUpdates = {

--- a/src/utils/typeDefaults.js
+++ b/src/utils/typeDefaults.js
@@ -1,0 +1,27 @@
+// Function to get the default size configured by the user
+export const getUserDefaultSize = (typeName, settings, database, dbToTypes) => {
+  const dbSettings = settings?.defaultTypeSizes?.[database] || {};
+  const userSize = dbSettings[typeName];
+  if (typeof userSize === 'number') {
+    return userSize;
+  }
+  return dbToTypes[database][typeName]?.defaultSize || '';
+};
+
+// Function to get the combined size for types with precision and scale
+export const getUserDefaultPrecisionScale = (typeName, settings, database) => {
+  const dbSettings = settings?.defaultTypeSizes?.[database] || {};
+  const userSettings = dbSettings[typeName];
+  if (typeof userSettings === 'object') {
+    const precision = userSettings?.precision || 10;
+    const scale = userSettings?.scale;
+    // If it has a defined scale, combine as "precision,scale"
+    if (scale !== undefined && scale !== null) {
+      return `${precision},${scale}`;
+    }
+    // If it only has precision, return just the precision
+    return precision.toString();
+  }
+  // Default value for types with precision
+  return "10";
+};


### PR DESCRIPTION
Fixed the logic for setting the default field size when changing a field’s type in the table editor.
- Moved the `getUserDefaultSize` and `getUserDefaultPrecisionScale` utility functions to a new file so they can be used when creating a new field and when editing  it.
- Updated the field type change handler to use these utility functions, using the user default size and precision values.

Fixes #47 