### PR TITLE
removed automatic uppercase and lowercase use based on default settings

### DIFF
--- a/src/components/EditorCanvas/Table.jsx
+++ b/src/components/EditorCanvas/Table.jsx
@@ -51,41 +51,6 @@ export default function Table(props) {
   const { t } = useTranslation();
   const { selectedElement, setSelectedElement } = useSelect();
 
-  useEffect(() => {
-    const desiredTableCase = settings.upperCaseFields
-      ? tableData.name.toUpperCase()
-      : tableData.name.toLowerCase();
-    const tableNameNeedsUpdate = tableData.name !== desiredTableCase;
-
-    const fieldsNeedUpdate = tableData.fields.some((field) => {
-      const desiredFieldCase = settings.upperCaseFields
-        ? field.name.toUpperCase()
-        : field.name.toLowerCase();
-      return field.name !== desiredFieldCase;
-    });
-
-    if (tableNameNeedsUpdate || fieldsNeedUpdate) {
-      const updatedFields = tableData.fields.map((field) => ({
-        ...field,
-        name: settings.upperCaseFields
-          ? field.name.toUpperCase()
-          : field.name.toLowerCase(),
-      }));
-
-      updateTable(tableData.id, {
-        name: settings.upperCaseFields
-          ? tableData.name.toUpperCase()
-          : tableData.name.toLowerCase(),
-        fields: updatedFields,
-      });
-    }
-  }, [
-    settings.upperCaseFields,
-    tableData.fields,
-    tableData.id,
-    tableData.name,
-    updateTable,
-  ]);
   const calculatedContentWidth = useMemo(() => {
     if (!tableData) return settings.tableWidth;
 

--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -70,9 +70,7 @@ export default function TableField({ data, tid, index }) {
             placeholder="Name"
             onChange={(value) =>
               updateField(tid, index, {
-                name: settings.upperCaseFields
-                  ? value.toUpperCase()
-                  : value.toLowerCase(),
+                name: value
               })
             }
             onKeyUp={(e) => {
@@ -105,9 +103,6 @@ export default function TableField({ data, tid, index }) {
             onFocus={(e) => setEditField({ name: e.target.value })}
             onBlur={(e) => {
               if (e.target.value === editField.name) return;
-              const transformedValue = settings.upperCaseFields
-                ? e.target.value.toUpperCase()
-                : e.target.value.toLowerCase();
               pushUndo({
                 action: Action.EDIT,
                 element: ObjectType.TABLE,
@@ -115,7 +110,7 @@ export default function TableField({ data, tid, index }) {
                 tid: tid,
                 fid: index,
                 undo: editField,
-                redo: { name: transformedValue },
+                redo: { name: e.target.value},
                 message: t("edit_table", {
                   tableName: tables[tid].name,
                   extra: "[field]",

--- a/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableInfo.jsx
@@ -43,23 +43,20 @@ export default function TableInfo({ data }) {
           placeholder={t("name")}
           className="ms-2"
           onChange={(value) => updateTable(data.id, {
-              name: settings.upperCaseFields ? value.toUpperCase() : value.toLowerCase()
+              name: value
           })}
           onFocus={(e) => setEditField({ name: e.target.value })}
           onBlur={(e) => {
             if (e.target.value === editField.name) return;
-            const transformedValue = settings.upperCaseFields
-              ? e.target.value.toUpperCase()
-              : e.target.value.toLowerCase();
             pushUndo({
               action: Action.EDIT,
               element: ObjectType.TABLE,
               component: "self",
               tid: data.id,
               undo: editField,
-              redo: { name: transformedValue },
+              redo: { name: e.target.value},
               message: t("edit_table", {
-                tableName: transformedValue,
+                tableName: e.target.value,
                 extra: "[name]",
               }),
             });
@@ -225,7 +222,7 @@ export default function TableInfo({ data }) {
         </Collapse>
       </Card>
       <div className="flex flex-col gap-1">
-      <div className="flex gap-1 w-full">  
+      <div className="flex gap-1 w-full">
         {!(settings.notation === Notation.CROWS_FOOT || settings.notation === Notation.IDEF1X)? (
           <Popover
             content={
@@ -275,7 +272,7 @@ export default function TableInfo({ data }) {
             />
           </Popover >
         ):null}
-      
+
         <div className="flex gap-1 flex grow">
           <Button
             block


### PR DESCRIPTION
This commit removes the automatic transformation of table and field names to uppercase or lowercase based on the default settings. Now the default value is only used when creating new fields and tables.