### PR TITLE
modification in the propagation of foreign key values ​​and avoid changes to foreign keys

### DIFF
--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -122,6 +122,7 @@ export default function TableField({ data, tid, index }) {
         </Col>
         <Col span={8}>
           <Select
+          disabled={!!data.foreignK}
             className="w-full"
             optionList={[
               ...Object.keys(dbToTypes[database]).map((value) => ({

--- a/src/components/EditorSidePanel/TablesTab/TableField.jsx
+++ b/src/components/EditorSidePanel/TablesTab/TableField.jsx
@@ -303,6 +303,7 @@ export default function TableField({ data, tid, index }) {
             <>
               <Col span={12}>
                 <InputNumber
+                  disabled={data.foreignK}
                   placeholder="Precision"
                   value={
                     data.size && data.size.includes(",")
@@ -344,6 +345,7 @@ export default function TableField({ data, tid, index }) {
               </Col>
               <Col span={12}>
                 <InputNumber
+                  disabled={data.foreignK}
                   placeholder="Scale"
                   value={
                     data.size && data.size.includes(",")
@@ -394,6 +396,7 @@ export default function TableField({ data, tid, index }) {
           ) : (
             <Col span={24}>
               <InputNumber
+                disabled={data.foreignK}
                 placeholder={t("Length/Size")}
                 value={data.size}
                 className="w-full"

--- a/src/context/DiagramContext.jsx
+++ b/src/context/DiagramContext.jsx
@@ -240,6 +240,42 @@ export default function DiagramContextProvider({ children }) {
             fields: newFields,
           };
         }
+        if (updatedValues.type||updatedValues.precision!=undefined||updatedValues.scale!=undefined||updatedValues.size!=undefined) {
+          const updatedFields = table.fields.map((f) => {
+            if (f.foreignK === true && f.foreignKey?.tableId === tid && f.foreignKey?.fieldId === fid) {
+              
+              const newType = updatedValues.type || f.type;
+              const dbSettings = settings?.defaultTypeSizes?.[database];
+              const typeDefaultConfig = dbSettings[newType];
+              
+              let newPrecision = f.precision;
+              let newScale = f.scale;
+              let newSize = f.size;
+
+              if (updatedValues.type !== undefined) {
+                if (typeof typeDefaultConfig === 'object') {
+                  newPrecision = typeDefaultConfig.precision ?? 10;
+                  newScale = typeDefaultConfig.scale ?? 2;
+                } else if (typeof typeDefaultConfig === 'number') {
+                    newSize = typeDefaultConfig;
+                }
+              }
+              if (updatedValues.precision !== undefined) newPrecision = updatedValues.precision;
+              if (updatedValues.scale !== undefined) newScale = updatedValues.scale;
+              if (updatedValues.size !== undefined) newSize = updatedValues.size;
+
+              return { 
+                ...f, 
+                type: newType,
+                precision: newPrecision,
+                scale: newScale,
+                size: newSize
+              };
+            }
+            return f;
+          });
+          return { ...table, fields: updatedFields };
+        }
         return table;
       }),
     );


### PR DESCRIPTION
Automatic propagation: Logic has been implemented so that any changes to the attributes of a primary key are automatically reflected in all related tables that use that foreign key (FK).

Edit restriction (Lock): Manual modification of foreign key dimensions in the user interface has been disabled. These values ​​can now only be managed from the primary table to ensure referential integrity. 
<img width="1240" height="524" alt="image" src="https://github.com/user-attachments/assets/9a25cbd6-539b-484b-8350-be59cf24716d" />

<img width="1040" height="528" alt="image" src="https://github.com/user-attachments/assets/2cb85aa3-749e-45e2-b25e-9a646f46bd07" />
